### PR TITLE
Add features for skipping parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ locals: {
 <p class="{{ isProduction(env) }}">in production!</p>
 ```
 
+#### Ignoring Expressions
+
+Many JavaScript frameworks use `{{` and `}}` as expression delimiters. It can even happen that another framework uses the same _custom_ delimiters you have defined in this plugin.
+
+You can tell the plugin to completely ignore an expression by prepending `@` to the delimiters:
+
+```html
+<p>The @{{ foo }} is strong with this one.</p>
+```
+
+Result:
+
+```html
+<p>The {{ foo }} is strong with this one.</p>
+```
+
 ### Conditionals
 
 Conditional logic uses normal html tags, and modifies/replaces them with the results of the logic. If there is any chance of a conflict with other custom tag names, you are welcome to change the tag names this plugin looks for in the options. For example, given the following config:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You have full control over the delimiters used for injecting locals, as well as 
 | **switchTags** | `['switch', 'case', 'default']` | Array containing names for tags used for `switch/case/default` statements |
 | **loopTags** | `['each']` | Array containing names for `for` loops |
 | **scopeTags** | `['scope']` | Array containing names for scopes |
+| **ignoredTag** | `'raw'` | String containing name of tag inside which parsing is disabled |
 
 ### Locals
 
@@ -255,6 +256,51 @@ locals: {
   <img class="profile__avatar" src="{{ image }}" alt="{{ name }}'s avatar" />
   <a class="profile__link" href="{{ link }}">more info</a>
 </div>
+```
+
+### Ignored tag
+
+Anything inside this tag will not be parsed, allowing you to output delimiters and anything the plugin would normally parse, in their original form.
+
+```html
+<raw>
+  <if condition="foo === 'bar'">
+    <p>Output {{ foo }} as-is</p>
+  </if>
+</raw>
+```
+
+```html
+<if condition="foo === 'bar'">
+  <p>Output {{ foo }} as-is</p>
+</if>
+```
+
+You can customize the name of the tag:
+
+```js
+var opts = {
+  ignoredTag: 'verbatim', 
+  locals: { foo: 'bar' } }
+}
+
+posthtml(expressions(opts))
+  .process(readFileSync('index.html', 'utf8'))
+  .then((result) => console.log(result.html))
+```
+
+```html
+<verbatim>
+  <if condition="foo === 'bar'">
+    <p>Output {{ foo }} as-is</p>
+  </if>
+</verbatim>
+```
+
+```html
+<if condition="foo === 'bar'">
+  <p>Output {{ foo }} as-is</p>
+</if>
 ```
 
 <h2 align="center">Maintainers</h2>

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,6 +153,19 @@ function walk (opts, nodes) {
 
     // if we have a string, match and replace it
     if (typeof node === 'string') {
+      // if node contains ignored expression delimiter, output as-is
+      let before = delimitersSettings[1].text[0]
+      let after = delimitersSettings[1].text[1]
+      const ignoredDelimiter = new RegExp(`@${before}(.+?)${after}`, 'g')
+
+      if (ignoredDelimiter.test(node)) {
+        node = node.replace(`@${before}`, before)
+
+        m.push(node)
+
+        return m
+      }
+
       node = placeholders(node, ctx, delimitersSettings)
 
       m.push(node)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const revertBackupedLocals = require('./backup').revert
 const placeholders = require('./placeholders')
 
 let delimitersSettings = []
-let conditionals, switches, loops, scopes
+let conditionals, switches, loops, scopes, ignored
 
 /**
  * @description Creates a set of local variables within the loop, and evaluates all nodes within the loop, returning their contents
@@ -86,7 +86,8 @@ module.exports = function postHTMLExpressions (options) {
     conditionalTags: ['if', 'elseif', 'else'],
     switchTags: ['switch', 'case', 'default'],
     loopTags: ['each'],
-    scopeTags: ['scope']
+    scopeTags: ['scope'],
+    ignoredTag: 'raw'
   }, options)
 
   // set tags
@@ -94,6 +95,7 @@ module.exports = function postHTMLExpressions (options) {
   scopes = options.scopeTags
   conditionals = options.conditionalTags
   switches = options.switchTags
+  ignored = options.ignoredTag
 
   // make a RegExp's to search for placeholders
   let before = escapeRegexpString(options.delimiters[0])
@@ -139,6 +141,15 @@ function walk (opts, nodes) {
   return nodes.reduce((m, node, i) => {
     // if we're skipping this node, return immediately
     if (skip) { skip--; return m }
+
+    // don't parse ignoredTag
+    if (node.tag === ignored) {
+      node.tag = false
+
+      m.push(node)
+
+      return m
+    }
 
     // if we have a string, match and replace it
     if (typeof node === 'string') {

--- a/test/expect/expression_ignored.html
+++ b/test/expect/expression_ignored.html
@@ -1,0 +1,4 @@
+{{ foo }}
+<p>
+  And here's a {{ variable }} that would be undefined.
+</p>

--- a/test/expect/raw.html
+++ b/test/expect/raw.html
@@ -1,3 +1,4 @@
   <if condition="foo === 'bar'">
     <p>Output {{ foo }} as is</p>
   </if>
+  <p class="@{{ dynamicClass }}">{{ foo }}</p>

--- a/test/expect/raw.html
+++ b/test/expect/raw.html
@@ -1,0 +1,3 @@
+  <if condition="foo === 'bar'">
+    <p>Output {{ foo }} as is</p>
+  </if>

--- a/test/expect/raw_custom.html
+++ b/test/expect/raw_custom.html
@@ -1,0 +1,4 @@
+  <if condition="foo === 'bar'">
+    <p>Output {{ foo }} as is</p>
+  </if>
+  <p class="@{{ dynamicClass }}">{{ foo }}</p>

--- a/test/fixtures/expression_ignored.html
+++ b/test/fixtures/expression_ignored.html
@@ -1,0 +1,4 @@
+@{{ foo }}
+<p>
+  And here's a @{{ variable }} that would be undefined.
+</p>

--- a/test/fixtures/raw.html
+++ b/test/fixtures/raw.html
@@ -2,4 +2,5 @@
   <if condition="foo === 'bar'">
     <p>Output {{ foo }} as is</p>
   </if>
+  <p class="@{{ dynamicClass }}">{{ foo }}</p>
 </raw>

--- a/test/fixtures/raw.html
+++ b/test/fixtures/raw.html
@@ -1,0 +1,5 @@
+<raw>
+  <if condition="foo === 'bar'">
+    <p>Output {{ foo }} as is</p>
+  </if>
+</raw>

--- a/test/fixtures/raw_custom.html
+++ b/test/fixtures/raw_custom.html
@@ -1,0 +1,6 @@
+<verbatim>
+  <if condition="foo === 'bar'">
+    <p>Output {{ foo }} as is</p>
+  </if>
+  <p class="@{{ dynamicClass }}">{{ foo }}</p>
+</verbatim>

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -77,3 +77,7 @@ test('Expressions - ignored', (t) => {
 test('Raw output', (t) => {
   return process(t, 'raw', { locals: { foo: 'bar' } })
 })
+
+test('Raw output - custom tag', (t) => {
+  return process(t, 'raw_custom', {ignoredTag: 'verbatim', locals: { foo: 'bar' } })
+})

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -70,6 +70,10 @@ test('Expressions - error', (t) => {
   })
 })
 
+test('Expressions - ignored', (t) => {
+  return process(t, 'expression_ignored', { locals: { foo: 'bar' } })
+})
+
 test('Raw output', (t) => {
   return process(t, 'raw', { locals: { foo: 'bar' } })
 })

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -37,6 +37,7 @@ function clean (html) {
   return html.replace(/[^\S\r\n]+$/gm, '').trim()
 }
 
+
 test('Basic', (t) => {
   return process(t, 'basic', { locals: { test: 'wow' } })
 })
@@ -67,4 +68,8 @@ test('Expressions - error', (t) => {
   return error('expression_error', (err) => {
     t.is(err.message, 'Invalid or unexpected token')
   })
+})
+
+test('Raw output', (t) => {
+  return process(t, 'raw', { locals: { foo: 'bar' } })
 })


### PR DESCRIPTION
## Proposed Changes

This PR adds two new features that allow outputting content as-is, basically skipping any parsing normally done by the plugin.

This is useful when you need to use the same syntax with other templating libraries.

### `<raw>` tag

You can now use the `<raw>` tag (configurable) to tell `posthtml-expressions` to skip parsing of everything inside it.

```html
<raw>
  <if condition="foo === 'bar'">
    <p>Output {{ foo }} as-is</p>
  </if>
</raw>
```

```html
<if condition="foo === 'bar'">
  <p>Output {{ foo }} as-is</p>
</if>
```

You can customize the name of the tag:

```js
var opts = {
  ignoredTag: 'verbatim', 
  locals: { foo: 'bar' } }
}

posthtml(expressions(opts))
  .process(readFileSync('index.html', 'utf8'))
  .then((result) => console.log(result.html))
```

```html
<verbatim>
  <if condition="foo === 'bar'">
    <p>Output {{ foo }} as-is</p>
  </if>
</verbatim>
```

```html
<if condition="foo === 'bar'">
  <p>Output {{ foo }} as-is</p>
</if>
```

### @ symbol

For one-offs where you need to output delimiters as-is and prevent the plugin from parsing expressions inside them, you can now use the [Blade-inspired](https://laravel.com/docs/5.8/blade#blade-and-javascript-frameworks) `@` symbol in front of them:

```html
<p>Here, @{{ foo }} will be output as it is.</p>
```

```html
<p>Here, {{ foo }} will be output as it is.</p>
```

## Types of Changes

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature which changes existing functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules