### PR TITLE
Fix expression ignoring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,7 +182,8 @@ function walk (opts, nodes) {
       const ignoredDelimiter = new RegExp(`@${before}(.+?)${after}`, 'g')
 
       if (ignoredDelimiter.test(node)) {
-        node = node.replace(`@${before}`, before)
+        const toReplace = new RegExp(`@${before}`, 'g')
+        node = node.replace(toReplace, before)
 
         m.push(node)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,16 +174,16 @@ function walk (opts, nodes) {
       return m
     }
 
+    const ignoredBefore = delimitersSettings[1].text[0]
+    const ignoredAfter = delimitersSettings[1].text[1]
+    const toReplace = new RegExp(`@${ignoredBefore}`, 'g')
+    let ignoredExpression = new RegExp(`@${ignoredBefore}(.+?)${ignoredAfter}`, 'g')
+
     // if we have a string, match and replace it
     if (typeof node === 'string') {
       // if node contains ignored expression delimiter, output as-is
-      const before = delimitersSettings[1].text[0]
-      const after = delimitersSettings[1].text[1]
-      const ignoredDelimiter = new RegExp(`@${before}(.+?)${after}`, 'g')
-
-      if (ignoredDelimiter.test(node)) {
-        const toReplace = new RegExp(`@${before}`, 'g')
-        node = node.replace(toReplace, before)
+      if (ignoredExpression.test(node)) {
+        node = node.replace(toReplace, ignoredBefore)
 
         m.push(node)
 
@@ -199,8 +199,14 @@ function walk (opts, nodes) {
 
     // if not, we have an object, so we need to run the attributes and contents
     if (node.attrs) {
+      // adapt regex to work with attribute values
+      ignoredExpression = new RegExp(`.*@${ignoredBefore}(.+?)${ignoredAfter}`)
       for (const key in node.attrs) {
-        node.attrs[key] = placeholders(node.attrs[key], ctx, delimitersSettings)
+        if (ignoredExpression.test(node.attrs[key])) {
+          node.attrs[key] = node.attrs[key].replace(toReplace, ignoredBefore)
+        } else {
+          node.attrs[key] = placeholders(node.attrs[key], ctx, delimitersSettings)
+        }
       }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const revertBackupedLocals = require('./backup').revert
 const placeholders = require('./placeholders')
 
 const delimitersSettings = []
-let conditionals, switches, loops, scopes, ignored
+let conditionals, switches, loops, scopes, ignored, ignoredBefore, ignoredAfter, toReplace, ignoredNodeExpression, ignoredAttrsExpression
 
 /**
  * @description Creates a set of local variables within the loop, and evaluates all nodes within the loop, returning their contents
@@ -147,6 +147,13 @@ module.exports = function postHTMLExpressions (options) {
     delimitersSettings[0] = delimiters[1]
     delimitersSettings[1] = delimiters[0]
   }
+  
+  
+  ignoredBefore = delimitersSettings[1].text[0]
+  ignoredAfter = delimitersSettings[1].text[1]
+  toReplace = new RegExp(`@${ignoredBefore}`, 'g')
+  ignoredNodeExpression = new RegExp(`@${ignoredBefore}(.+?)${ignoredAfter}`, 'g')
+  ignoredAttrsExpression = new RegExp(`.*@${ignoredBefore}(.+?)${ignoredAfter}`)
 
   // kick off the parsing
   return walk.bind(null, { locals: options.locals })
@@ -173,12 +180,6 @@ function walk (opts, nodes) {
 
       return m
     }
-
-    const ignoredBefore = delimitersSettings[1].text[0]
-    const ignoredAfter = delimitersSettings[1].text[1]
-    const toReplace = new RegExp(`@${ignoredBefore}`, 'g')
-    const ignoredNodeExpression = new RegExp(`@${ignoredBefore}(.+?)${ignoredAfter}`, 'g')
-    const ignoredAttrsExpression = new RegExp(`.*@${ignoredBefore}(.+?)${ignoredAfter}`)
 
     // if we have a string, match and replace it
     if (typeof node === 'string') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,12 +177,13 @@ function walk (opts, nodes) {
     const ignoredBefore = delimitersSettings[1].text[0]
     const ignoredAfter = delimitersSettings[1].text[1]
     const toReplace = new RegExp(`@${ignoredBefore}`, 'g')
-    let ignoredExpression = new RegExp(`@${ignoredBefore}(.+?)${ignoredAfter}`, 'g')
+    const ignoredNodeExpression = new RegExp(`@${ignoredBefore}(.+?)${ignoredAfter}`, 'g')
+    const ignoredAttrsExpression = new RegExp(`.*@${ignoredBefore}(.+?)${ignoredAfter}`)
 
     // if we have a string, match and replace it
     if (typeof node === 'string') {
       // if node contains ignored expression delimiter, output as-is
-      if (ignoredExpression.test(node)) {
+      if (ignoredNodeExpression.test(node)) {
         node = node.replace(toReplace, ignoredBefore)
 
         m.push(node)
@@ -199,10 +200,8 @@ function walk (opts, nodes) {
 
     // if not, we have an object, so we need to run the attributes and contents
     if (node.attrs) {
-      // adapt regex to work with attribute values
-      ignoredExpression = new RegExp(`.*@${ignoredBefore}(.+?)${ignoredAfter}`)
       for (const key in node.attrs) {
-        if (ignoredExpression.test(node.attrs[key])) {
+        if (ignoredAttrsExpression.test(node.attrs[key])) {
           node.attrs[key] = node.attrs[key].replace(toReplace, ignoredBefore)
         } else {
           node.attrs[key] = placeholders(node.attrs[key], ctx, delimitersSettings)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const revertBackupedLocals = require('./backup').revert
 const placeholders = require('./placeholders')
 
 const delimitersSettings = []
-let conditionals, switches, loops, scopes, ignored, ignoredBefore, ignoredAfter, toReplace, ignoredNodeExpression, ignoredAttrsExpression
+let conditionals, switches, loops, scopes, ignored, delimitersReplace, unescapeDelimitersReplace
 
 /**
  * @description Creates a set of local variables within the loop, and evaluates all nodes within the loop, returning their contents
@@ -124,12 +124,12 @@ module.exports = function postHTMLExpressions (options) {
   let before = escapeRegexpString(options.delimiters[0])
   let after = escapeRegexpString(options.delimiters[1])
 
-  const delimitersRegexp = new RegExp(`${before}(.+?)${after}`, 'g')
+  const delimitersRegexp = new RegExp(`(?<!@)${before}(.+?)${after}`, 'g')
 
   before = escapeRegexpString(options.unescapeDelimiters[0])
   after = escapeRegexpString(options.unescapeDelimiters[1])
 
-  const unescapeDelimitersRegexp = new RegExp(`${before}(.+?)${after}`, 'g')
+  const unescapeDelimitersRegexp = new RegExp(`(?<!@)${before}(.+?)${after}`, 'g')
 
   // make array of delimiters
   const delimiters = [
@@ -147,13 +147,9 @@ module.exports = function postHTMLExpressions (options) {
     delimitersSettings[0] = delimiters[1]
     delimitersSettings[1] = delimiters[0]
   }
-  
-  
-  ignoredBefore = delimitersSettings[1].text[0]
-  ignoredAfter = delimitersSettings[1].text[1]
-  toReplace = new RegExp(`@${ignoredBefore}`, 'g')
-  ignoredNodeExpression = new RegExp(`@${ignoredBefore}(.+?)${ignoredAfter}`, 'g')
-  ignoredAttrsExpression = new RegExp(`.*@${ignoredBefore}(.+?)${ignoredAfter}`)
+
+  delimitersReplace = new RegExp(`@${delimitersSettings[1].text[0]}`, 'g')
+  unescapeDelimitersReplace = new RegExp(`@${delimitersSettings[0].text[0]}`, 'g')
 
   // kick off the parsing
   return walk.bind(null, { locals: options.locals })
@@ -183,16 +179,10 @@ function walk (opts, nodes) {
 
     // if we have a string, match and replace it
     if (typeof node === 'string') {
-      // if node contains ignored expression delimiter, output as-is
-      if (ignoredNodeExpression.test(node)) {
-        node = node.replace(toReplace, ignoredBefore)
-
-        m.push(node)
-
-        return m
-      }
-
       node = placeholders(node, ctx, delimitersSettings)
+      node = node
+        .replace(unescapeDelimitersReplace, delimitersSettings[0].text[0])
+        .replace(delimitersReplace, delimitersSettings[1].text[0])
 
       m.push(node)
 
@@ -202,11 +192,10 @@ function walk (opts, nodes) {
     // if not, we have an object, so we need to run the attributes and contents
     if (node.attrs) {
       for (const key in node.attrs) {
-        if (ignoredAttrsExpression.test(node.attrs[key])) {
-          node.attrs[key] = node.attrs[key].replace(toReplace, ignoredBefore)
-        } else {
-          node.attrs[key] = placeholders(node.attrs[key], ctx, delimitersSettings)
-        }
+        node.attrs[key] = placeholders(node.attrs[key], ctx, delimitersSettings)
+        node.attrs[key] = node.attrs[key]
+          .replace(unescapeDelimitersReplace, delimitersSettings[0].text[0])
+          .replace(delimitersReplace, delimitersSettings[1].text[0])
       }
     }
 

--- a/test/expect/expression_ignored.html
+++ b/test/expect/expression_ignored.html
@@ -1,4 +1,4 @@
 {{ foo }}
-<p data-user-id="{{ user.id }}">
+<p data-username="{{ user.name }}" data-user-id="user-{{ user.id }}">
   Here's one {{ variable }} and here's {{ another }}.
 </p>

--- a/test/expect/expression_ignored.html
+++ b/test/expect/expression_ignored.html
@@ -1,4 +1,4 @@
 {{ foo }}
 <p>
-  And here's a {{ variable }} that would be undefined.
+  Here's one {{ variable }} and here's {{ another }}.
 </p>

--- a/test/expect/expression_ignored.html
+++ b/test/expect/expression_ignored.html
@@ -1,4 +1,4 @@
 {{ foo }}
-<p data-username="{{ user.name }}" data-user-id="user-{{ user.id }}">
-  Here's one {{ variable }} and here's {{ another }}.
+<p data-username="{{ user.name }}" data-user-id="user-{{ user.id }}-bar-{{ foo }}">
+  Here's one {{ variable }} and here's {{ another }}. And some bar.
 </p>

--- a/test/expect/expression_ignored.html
+++ b/test/expect/expression_ignored.html
@@ -1,4 +1,4 @@
 {{ foo }}
-<p>
+<p data-user-id="{{ user.id }}">
   Here's one {{ variable }} and here's {{ another }}.
 </p>

--- a/test/fixtures/expression_ignored.html
+++ b/test/fixtures/expression_ignored.html
@@ -1,4 +1,4 @@
 @{{ foo }}
-<p>
+<p data-user-id="@{{ user.id }}">
   Here's one @{{ variable }} and here's @{{ another }}.
 </p>

--- a/test/fixtures/expression_ignored.html
+++ b/test/fixtures/expression_ignored.html
@@ -1,4 +1,4 @@
 @{{ foo }}
 <p>
-  And here's a @{{ variable }} that would be undefined.
+  Here's one @{{ variable }} and here's @{{ another }}.
 </p>

--- a/test/fixtures/expression_ignored.html
+++ b/test/fixtures/expression_ignored.html
@@ -1,4 +1,4 @@
 @{{ foo }}
-<p data-username="@{{ user.name }}" data-user-id="user-@{{ user.id }}">
-  Here's one @{{ variable }} and here's @{{ another }}.
+<p data-username="@{{ user.name }}" data-user-id="user-@{{ user.id }}-{{ foo }}-@{{ foo }}">
+  Here's one @{{ variable }} and here's @{{ another }}. And some {{ foo }}.
 </p>

--- a/test/fixtures/expression_ignored.html
+++ b/test/fixtures/expression_ignored.html
@@ -1,4 +1,4 @@
 @{{ foo }}
-<p data-user-id="@{{ user.id }}">
+<p data-username="@{{ user.name }}" data-user-id="user-@{{ user.id }}">
   Here's one @{{ variable }} and here's @{{ another }}.
 </p>

--- a/test/test-conditionals.js
+++ b/test/test-conditionals.js
@@ -23,7 +23,7 @@ function process (t, name, options, log = false) {
       return clean(result.html)
     })
     .then((html) => {
-      t.truthy(html === expect(name).trim())
+      t.is(html, expect(name).trim())
     })
 }
 
@@ -51,13 +51,13 @@ test('Conditionals - no render', (t) => {
 
 test('Conditionals - "if" tag missing condition', (t) => {
   return error('conditional_if_error', (err) => {
-    t.truthy(err.toString() === 'Error: the "if" tag must have a "condition" attribute')
+    t.is(err.toString(), 'Error: the "if" tag must have a "condition" attribute')
   })
 })
 
 test('Conditionals - "elseif" tag missing condition', (t) => {
   return error('conditional_elseif_error', (err) => {
-    t.truthy(err.toString() === 'Error: the "elseif" tag must have a "condition" attribute')
+    t.is(err.toString(), 'Error: the "elseif" tag must have a "condition" attribute')
   })
 })
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -23,7 +23,7 @@ function process (t, name, options, log = false) {
       return clean(result.html)
     })
     .then((html) => {
-      t.truthy(html === expect(name).trim())
+      t.is(html, expect(name).trim())
     })
 }
 

--- a/test/test-scopes.js
+++ b/test/test-scopes.js
@@ -23,7 +23,7 @@ function process (t, name, options, log = false) {
       return clean(result.html)
     })
     .then((html) => {
-      t.truthy(html === expect(name).trim())
+      t.is(html, expect(name).trim())
     })
 }
 

--- a/test/test-switch.js
+++ b/test/test-switch.js
@@ -23,7 +23,7 @@ function process (t, name, options, log = false) {
       return clean(result.html)
     })
     .then((html) => {
-      t.truthy(html === expect(name).trim())
+      t.is(html, expect(name).trim())
     })
 }
 
@@ -75,7 +75,7 @@ test('Switch - dynamic expression', (t) => {
 
 test('Switch - no switch attribute', (t) => {
   return error('switch_no_attr', (err) => {
-    t.truthy(err.toString() === 'Error: the "switch" tag must have a "expression" attribute')
+    t.is(err.toString(), 'Error: the "switch" tag must have a "expression" attribute')
   })
 })
 


### PR DESCRIPTION
This PR fixes a couple of bugs when ignoring expressions with `@{{ }}`, as described in #72.

Subsequent ignored expressions now properly work in text nodes:

```html
<p>Here's one @{{ variable }} and here's @{{ another }}.</p>
```

Result:

```html
<p>Here's one {{ variable }} and here's {{ another }}.</p>
```

Expressions are now also ignored inside attribute values:

```html
<p data-foo="@{{ bar }}">Lorem ipsum.</p>
```

Result:

```html
<p data-foo="{{ bar }}">Lorem ipsum.</p>
```

When merged, this PR will close #72.