### PR TITLE
fix: escape custom delimiters when ignoring expressions

### DIFF
--- a/lib/escape.js
+++ b/lib/escape.js
@@ -11,7 +11,7 @@
  */
 function escapeRegexpString (input) {
   // match Operators
-  const match = /[|\\{}()[\]^$+*?.]/
+  const match = /[|\\{}()[\]^$+*?.]/g
 
   return input.replace(match, '\\$&')
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,8 +148,8 @@ module.exports = function postHTMLExpressions (options) {
     delimitersSettings[1] = delimiters[0]
   }
 
-  delimitersReplace = new RegExp(`@${delimitersSettings[1].text[0]}`, 'g')
-  unescapeDelimitersReplace = new RegExp(`@${delimitersSettings[0].text[0]}`, 'g')
+  delimitersReplace = new RegExp(`@${escapeRegexpString(delimitersSettings[1].text[0])}`, 'g')
+  unescapeDelimitersReplace = new RegExp(`@${escapeRegexpString(delimitersSettings[0].text[0])}`, 'g')
 
   // kick off the parsing
   return function (tree) {

--- a/test/fixtures/custom_delimiters.html
+++ b/test/fixtures/custom_delimiters.html
@@ -1,3 +1,3 @@
-x {% test %} x {% 1 + 1 %} x
-<p class="x {% test %} x">x {% test %} x</p>
-{{% 'x&x' %}}
+x %[ test ]% x %[ 1 + 1 ]% x
+<p class="x %[ test ]% x">x %[ test ]% x</p>
+%[[ 'x&x' ]]%

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -54,8 +54,8 @@ test('Unescaped', (t) => {
 
 test('Delimiters', (t) => {
   return process(t, 'custom_delimiters', {
-    delimiters: ['{%', '%}'],
-    unescapeDelimiters: ['{{%', '%}}'],
+    delimiters: ['%[', ']%'],
+    unescapeDelimiters: ['%[[', ']]%'],
     locals: { test: 'wow' }
   })
 })


### PR DESCRIPTION
This PR fixes an invalid regex issue that occured with some custom delimiters when ignoring expressions. Basically, we forgot to also escape the regex when ignoring expressions with `@{{ }}`, like we do for expressions in general. 

So when someone used some custom delimiters that actually needed escaping for use in a regex, even though they weren't using `@{{ }}` in their code, this was still breaking, resulting in a `Invalid regular expression/Unterminated character class` syntax error.

Fixes #88.