### PR TITLE
feat: allow script locals to use global locals

### DIFF
--- a/lib/locals.js
+++ b/lib/locals.js
@@ -5,10 +5,7 @@ const matchHelper = require('posthtml-match-helper')
 const { render } = require('posthtml-render')
 const { match } = require('posthtml/lib/api')
 
-// const code = 'module.exports = {a: 1}';
 const ctx = vm.createContext({ module })
-
-// const r = vm.runInContext(code, ctx)
 
 /**
  * @description Get the script tag with locals attribute from a node list and return locals.
@@ -22,13 +19,15 @@ const ctx = vm.createContext({ module })
 function scriptDataLocals (tree, options) {
   const locals = {}
   const localsAttr = options.localsAttr
+  const localsContext = options.locals || {}
 
   match.call(tree, matchHelper(`script[${localsAttr}]`), node => {
     if (node.content) {
       const code = render(node.content)
 
       try {
-        const local = vm.runInContext(code, ctx)
+        const parsedContext = vm.createContext({ ...ctx, locals: localsContext })
+        const local = vm.runInContext(code, parsedContext)
 
         Object.assign(locals, local)
       } catch {};

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,38 @@ You can also use the script tag with the attribute `locals` or you custome attri
 <div>My name: Scrum</div>
 ```
 
+In addition, the use of script tag allow you to use `locals` defined globally to assign data to variables.
+
+```js
+posthtml(expressions({ locals: { foo: 'bar' } }))
+  .process(readFileSync('index.html', 'utf8'))
+  .then((result) => console.log(result.html))
+```
+
+```html
+<script locals>
+  module.exports = {
+    name: 'Scrum',
+    foo: locals.foo || 'empty'
+  }
+</script>
+
+<div>My name: {{name}}</div>
+<div>Foo: {{foo}}</div>
+```
+
+```html
+<script locals>
+  module.exports = {
+    name: 'Scrum',
+    foo: locals.foo || 'empty'
+  }
+</script>
+
+<div>My name: {{name}}</div>
+<div>Foo: bar</div>
+```
+
 ### Unescaped Locals
 
 By default, special characters will be escaped so that they show up as text, rather than html code. For example, if you had a local containing valid html as such:
@@ -444,7 +476,7 @@ You can customize the name of the tag:
 
 ```js
 var opts = {
-  ignoredTag: 'verbatim', 
+  ignoredTag: 'verbatim',
   locals: { foo: 'bar' } }
 }
 

--- a/test/expect/script-locals-global-not-informed.html
+++ b/test/expect/script-locals-global-not-informed.html
@@ -1,0 +1,9 @@
+<script locals="">
+  module.exports = {
+    name: 'Scrum',
+    age: locals.displayAge ? '25' : 'not informed'
+  }
+</script>
+
+<div>My name: Scrum</div>
+<div>My age: not informed</div>

--- a/test/expect/script-locals-global.html
+++ b/test/expect/script-locals-global.html
@@ -1,0 +1,9 @@
+<script locals="">
+  module.exports = {
+    name: 'Scrum',
+    age: locals.displayAge ? '25' : 'not informed'
+  }
+</script>
+
+<div>My name: Scrum</div>
+<div>My age: 25</div>

--- a/test/fixtures/script-locals-global-not-informed.html
+++ b/test/fixtures/script-locals-global-not-informed.html
@@ -1,0 +1,9 @@
+<script locals>
+  module.exports = {
+    name: 'Scrum',
+    age: locals.displayAge ? '25' : 'not informed'
+  }
+</script>
+
+<div>My name: {{name}}</div>
+<div>My age: {{ age }}</div>

--- a/test/fixtures/script-locals-global.html
+++ b/test/fixtures/script-locals-global.html
@@ -1,0 +1,9 @@
+<script locals>
+  module.exports = {
+    name: 'Scrum',
+    age: locals.displayAge ? '25' : 'not informed'
+  }
+</script>
+
+<div>My name: {{name}}</div>
+<div>My age: {{ age }}</div>

--- a/test/test-locals.js
+++ b/test/test-locals.js
@@ -35,6 +35,14 @@ test('Basic', (t) => {
   return process(t, 'script-locals')
 })
 
+test('Global Locals - setting global locals', (t) => {
+  return process(t, 'script-locals-global', { locals: { displayAge: true } })
+})
+
+test('Global Locals - no global locals informed', (t) => {
+  return process(t, 'script-locals-global-not-informed')
+})
+
 test('Remove script locals', (t) => {
   return process(t, 'script-locals-remove', { removeScriptLocals: true })
 })


### PR DESCRIPTION
## Proposed Changes

The intent of this PR is to add support to allow script locals to use global locals defined.

I faced a situation simular to https://github.com/posthtml/posthtml-expressions/issues/132, where I needed to access a global value from my template file, while using the `posthtml-include` plugin.

Example:

```js
posthtml({
      plugins: [
        include({ posthtmlExpressionsOptions: { 
         removeScriptLocals: true, 
         locals: {}
       })
      ],
})
```

```html
<!-- src/components/ordered-list.html -->
<script locals>
  module.exports = {
    start: locals?.props?.startAt || 1,
  }
</script>

<div class="w-full ordered-list">
  <each loop="item, index in (props.list || [])">
    <p
      class="border-b-2 border-gray-400 font-stabil font-medium uppercase pb-1 sm:pb-3 3xl:pb-4">
      <span class="text-sm"> ({{ start++ }}) </span>
      <span class="text-left"> {{ item }} </span>
    </p>
  </each>
</div>
```


```html
<include src="src/components/ordered-list.html">
{
  "props": {
    "list": [
      "activista la",
      "activista la",
    ],
    "startAt": 10
  }
}
</include>
```

Generated output:

```html
<div class="w-full ordered-list">
    <p class="border-b-2 border-gray-400 font-stabil font-medium uppercase pb-1 sm:pb-3 3xl:pb-4">
      <span class="text-sm"> (20) </span>
      <span class="text-left"> activista la </span>
    </p>
  
    <p class="border-b-2 border-gray-400 font-stabil font-medium uppercase pb-1 sm:pb-3 3xl:pb-4">
      <span class="text-sm"> (21) </span>
      <span class="text-left"> activista la </span>
    </p>
</div>
```


## Types of Changes

What types of changes does your code introduce
_Put an `x` in the boxes that apply_

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature which changes existing functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is a reminder of what we are going to look for before merging your
code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules

## Further Comments

If this is a large or complex change, kick off the discussion by explaining why
you chose the solution you did and what alternatives you considered, etc...

### Reviewers:  @mrmlnc, @jescalan, @michael-ciniawsky, @posthtml/collaborators
