### PR TITLE
Changed package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "fclone": "^1.0.11",
     "posthtml-match-helper": "^1.0.1",
     "posthtml-parser": "^0.10.0",
+    "posthtml": "^0.16.5",
     "posthtml-render": "^3.0.0"
   },
   "devDependencies": {
     "ava": "^3.15.0",
     "jsdoc-to-markdown": "^7.0.1",
     "nyc": "^15.1.0",
-    "posthtml": "^0.16.5",
     "posthtml-beautify": "^0.7.0",
     "standard": "^16.0.3",
     "standard-changelog": "^2.0.27"


### PR DESCRIPTION
## Proposed Changes

Moved a line indicating a dependency on `posthtml` from _devDependencies_ to _dependencies_.
This should allow you to run the plugin in `plug'n'play` mode in the `yarn` package manager.
Done for this issue: #151

## Types of Changes

- [x] Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/posthtml/posthtml-expressions/blob/7a5317d61d38dd774b3978b343d60946da21b800/.github/contributing.md) guide
