### PR TITLE
Fix regex generated for special characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,14 +128,16 @@ module.exports = function postHTMLExpressions (options) {
 
   // Define regex to search for placeholders
   let before = escapeRegexpString(options.delimiters[0])
+  let firstChar = escapeRegexpString(options.delimiters[0][0])
   let after = escapeRegexpString(options.delimiters[1])
 
-  const delimitersRegexp = new RegExp(`(?<!@${options.delimiters[0][0]}?)${before}(.+?)${after}`, 'g')
+  const delimitersRegexp = new RegExp(`(?<!@${firstChar}?)${before}(.+?)${after}`, 'g')
 
   before = escapeRegexpString(options.unescapeDelimiters[0])
+  firstChar = escapeRegexpString(options.unescapeDelimiters[0][0])
   after = escapeRegexpString(options.unescapeDelimiters[1])
 
-  const unescapeDelimitersRegexp = new RegExp(`(?<!@${options.unescapeDelimiters[0][0]}?)${before}(.+?)${after}`, 'g')
+  const unescapeDelimitersRegexp = new RegExp(`(?<!@${firstChar}?)${before}(.+?)${after}`, 'g')
 
   // Create an array of delimiters
   const delimiters = [

--- a/test/expect/expression_custom_delimiters_ignored.html
+++ b/test/expect/expression_custom_delimiters_ignored.html
@@ -1,0 +1,8 @@
+${ foo }
+<p data-username="${ user.name }" data-user-id="user-${ user.id }-bar-${ bar }">
+  Here's one ${ variable } and here's ${ another }. And some bar.
+</p>
+
+ignored: ${ leaveAsIs }
+ignoredUnescaped: ${{ leaveAsIs }}
+rendered: bar

--- a/test/fixtures/expression_custom_delimiters_ignored.html
+++ b/test/fixtures/expression_custom_delimiters_ignored.html
@@ -1,0 +1,8 @@
+@${ foo }
+<p data-username="@${ user.name }" data-user-id="user-@${ user.id }-${ foo }-@${ bar }">
+  Here's one @${ variable } and here's @${ another }. And some ${ foo }.
+</p>
+
+ignored: @${ leaveAsIs }
+ignoredUnescaped: @${{ leaveAsIs }}
+rendered: ${ foo }

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -74,6 +74,14 @@ test('Expressions - ignored', (t) => {
   return process(t, 'expression_ignored', { locals: { foo: 'bar' } })
 })
 
+test('Expressions with custom delimiters - ignored', (t) => {
+  return process(t, 'expression_custom_delimiters_ignored', {
+    delimiters: ['${', '}'],
+    unescapeDelimiters: ['${{', '}}'],
+    locals: { foo: 'bar' }
+  })
+})
+
 test('Raw output', (t) => {
   return process(t, 'raw', { locals: { foo: 'bar' } })
 })


### PR DESCRIPTION
#157 introduced a bug resulting in an invalid regex if custom delimiters are starting with a regex special character.